### PR TITLE
Add blocking argument to `ChannelUnbounded`'s read

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -48,22 +48,29 @@ public:
      *        This could be used to process items until a channel
      *        is closed and drained.
      * @param
+     *      value
      *        The variable in which it will be put the value from the
      *        channel.
+     *      wait
+     *        Controls whether it blocks until an item is available
+     *        or the channel is closed.
+     *        By default is set to `true` to be blocking.
      * @return
      *        `true`, if an item was received.
      *        `false`, if there was no item to read from the channel, i. e.
      *                 the channel was empty.
      */
-    bool read(T& value) {
+    bool read(T& value, bool wait = true) {
         std::unique_lock<std::mutex> lock(mutex);
 
-        conditionalVariable.wait(
-            lock,
-            [&]() {
-                return closed || (!queue.empty());
-            }
-        );
+        if (wait) {
+            conditionalVariable.wait(
+                lock,
+                [&]() {
+                    return closed || (!queue.empty());
+                }
+            );
+        }
 
         if (queue.empty()) {
             return false;


### PR DESCRIPTION
These changes are a prerequisite for the `select`-like behavior for channels.

The second argument to the `read()` method controls whether it blocks
until an item is available or the channel is closed.

To do something like a `select` from Golang over multiple channels,
we can do this:

```C++
Type1 item1;
Type2 item2;

if (channel1.get(item1, false)) {
  // ...
} else if (channel2.get(item2, false)) {
  // ...
}
```

This PR is on top of https://github.com/marius92mc/csp-cpp/pull/3 and will be rebased against `develop` as soon as that PR is merged. 
LE: done. 
Against `master` in the end. 