### PR TITLE
Extend task group

### DIFF
--- a/src/tbb/examples/task_group/sudoku/channel.cpp
+++ b/src/tbb/examples/task_group/sudoku/channel.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <queue>
+#include <unordered_map>
 
 #include "tbb/atomic.h"
 #include "tbb/tick_count.h"
@@ -26,6 +27,8 @@ const unsigned int gKDefaultnumberOfChannels = 20;
  * there's no way count would have different values in different threads.
  */
 atomic<int> trigger;
+std::unordered_map<std::string, int> channelToIndex;
+std::unordered_map<int, std::string> indexToChannel;
 
 
 int getRandom() {
@@ -39,15 +42,20 @@ class Hello {
     const int kSecondsLimit;
 public:
     Hello(
-        std::string operation, int indexChannel, int content = 0
+        std::string operation, const std::string& channelName, int content = 0
     ): kSecondsLimit(5) {
       if (operation != "push" && operation != "pop") {
         std::cout << "Not a valid operation.\n";
         return;
       }
+      if (channelToIndex.find(channelName) == channelToIndex.end()) {
+        std::cout << "On " << operation << " not a valid channel name: " << channelName << ".\n";
+        return;
+      }
+      const int indexChannel = channelToIndex[channelName];
       if (!isValidIndex(indexChannel)) {
         std::cout << "On " << operation
-                  << " not a valid channel: " << indexChannel << ".\n";
+                  << " not a valid channel index: " << indexChannel << ".\n";
         return;
       }
 
@@ -57,7 +65,7 @@ public:
 
       if (operation == "pop") {
         if (gQueues[indexChannel].size() < 1) {
-          std::cout << "Can't pop on empty channel " << indexChannel << ".\n";
+          std::cout << "Can't pop on empty channel " << channelName << ".\n";
           return;
         }
         gQueues[indexChannel].pop();
@@ -116,7 +124,10 @@ public:
         // an item from a channel was received,
         // more precisely from the channel with index `trigger`,
         // because of the `trigger.fetch_and_add(indexChannel)` call.
-        std::cout << "Received item from channel " << trigger << ".\n";
+        if (indexToChannel.find(trigger) == indexToChannel.end()) {
+          std::cout << "Trigger not set properly.\n";
+        }
+        std::cout << "Received item from channel " << indexToChannel[trigger] << ".\n";
 
         // When an item is received, cancel all the other channels.
         tg.cancel();
@@ -148,33 +159,55 @@ public:
   }
 };
 
+/*
+ * Put default trigger to 0, as untriggered.
+ */
+void setTriggerToDefault() {
+  trigger = 0;
+}
+
+
+void setHashTables() {
+  channelToIndex.clear();
+  indexToChannel.clear();
+
+  channelToIndex["channel1"] = 1;
+  channelToIndex["channel2"] = 2;
+  channelToIndex["channel3"] = 3;
+  indexToChannel[1] = "channel1";
+  indexToChannel[2] = "channel2";
+  indexToChannel[3] = "channel3";
+}
+
 
 void showExampleGeneral() {
   std::cout << "\n---------- Example - General behaviour ----------\n";
 
+  // IMPORTANT
+  // We have to hardcode this statement everytime in the injected code area, because this is the place where it works to be, 
+  // in order to have the desired behaviour. 
+  setTriggerToDefault();
+
   gQueues.clear();
   gQueues.resize(gKDefaultnumberOfChannels); // TODO change this
 
-  // IMPORTANT
-  // We have to harcode this statement everytime in the injected code area, because this is the place where it works to be, 
-  // in order to have the desired behaviour. 
-  trigger = 0;
-
   task_group tg;
 
+  setHashTables();
+
   // queue indices starting with 1, to have effect the fetch_and_add(number)
-  tg.run(Hello("push", 1, 5));
-  tg.run(Hello("push", 1, 8));
-  tg.run(Hello("push", 2, 10));
-  tg.run(Hello("push", 3, 5));
+  tg.run(Hello("push", "channel1", 5));
+  tg.run(Hello("push", "channel1", 8));
+  tg.run(Hello("push", "channel2", 10));
+  tg.run(Hello("push", "channel3", 5));
 
-  const unsigned int randomIndexChannel = (getRandom() % 3) + 1;
+  std::vector<std::string> channelNames = {"channel1", "channel2", "channel3"};
+  const std::string randomChannelName = channelNames[getRandom() % 3]; 
 
-  std::cout << "Gonna pop from channel " << randomIndexChannel << ".\n";
+  std::cout << "Gonna pop from channel " << randomChannelName << ".\n";
   // This pop is hardcoded for the example, but it actually triggers
   // when the first pop is encountered.
-  tg.run(Hello("pop", randomIndexChannel));
-  //tg.run(Hello("pop", 4));
+  tg.run(Hello("pop", randomChannelName));
 
   tg.run(DefaultTimer(5));
 
@@ -187,24 +220,28 @@ void showExampleGeneral() {
 void showExamplePopFromEmptyChannel() {
   std::cout << "\n---------- Example - pop() from empty channel ----------\n";
 
+  setTriggerToDefault();
+
   gQueues.clear();
   gQueues.resize(gKDefaultnumberOfChannels); // TODO change this
 
-  trigger = 0;
   task_group tg;
 
+
+  setHashTables();
+  channelToIndex["channel4"] = 4;
+  indexToChannel[4] = "channel4";
+
   // queue indices starting with 1, to have effect the fetch_and_add(number)
-  tg.run(Hello("push", 1, 5));
-  tg.run(Hello("push", 1, 8));
-  tg.run(Hello("push", 2, 10));
-  tg.run(Hello("push", 3, 5));
+  tg.run(Hello("push", "channel1", 5));
+  tg.run(Hello("push", "channel1", 8));
+  tg.run(Hello("push", "channel2", 10));
+  tg.run(Hello("push", "channel3", 5));
 
-  const unsigned int indexChannel = 4;
-
-  std::cout << "Gonna pop from channel " << indexChannel << ".\n";
+  std::cout << "Gonna pop from channel channel4.\n";
   // This pop is hardcoded for the example, but it actually triggers
   // when the first pop is encountered.
-  tg.run(Hello("pop", indexChannel));
+  tg.run(Hello("pop", "channel4"));
 
   tg.run(DefaultTimer(5));
 
@@ -221,17 +258,20 @@ void showExampleDefaultCase(const int& numberOfSeconds = 5) {
   std::cout << "\n---------- Example - reaching default case after "
             << numberOfSeconds << " seconds ----------\n";
 
+  setTriggerToDefault();
+
   gQueues.clear();
   gQueues.resize(gKDefaultnumberOfChannels); // TODO change this
 
-  trigger = 0;
   task_group tg;
 
+  setHashTables();
+
   // queue indices starting with 1, to have effect the fetch_and_add(number)
-  tg.run(Hello("push", 1, 5));
-  tg.run(Hello("push", 1, 8));
-  tg.run(Hello("push", 2, 10));
-  tg.run(Hello("push", 3, 5));
+  tg.run(Hello("push", "channel1", 5));
+  tg.run(Hello("push", "channel1", 8));
+  tg.run(Hello("push", "channel2", 10));
+  tg.run(Hello("push", "channel3", 5));
 
   // We haven't called any pop(), so the default case will be triggered.
   tg.run(DefaultTimer(numberOfSeconds));
@@ -244,20 +284,23 @@ void showExampleDefaultCase(const int& numberOfSeconds = 5) {
 void showExampleNotAValidChannel() {
   std::cout << "\n---------- Example - not a valid channel ----------\n";
 
+  setTriggerToDefault();
+
   gQueues.clear();
   gQueues.resize(gKDefaultnumberOfChannels); // TODO change this
 
-  trigger = 0;
   task_group tg;
 
-  // queue indices starting with 1, to have effect the fetch_and_add(number)
-  tg.run(Hello("push", 1, 5));
-  tg.run(Hello("push", 1, 8));
-  tg.run(Hello("push", 2, 10));
-  tg.run(Hello("push", 3, 5));
+  setHashTables();
 
-  tg.run(Hello("push", gKDefaultnumberOfChannels + 1, 1));
-  tg.run(Hello("pop", gKDefaultnumberOfChannels + 2, 2));
+  // queue indices starting with 1, to have effect the fetch_and_add(number)
+  tg.run(Hello("push", "channel1", 5));
+  tg.run(Hello("push", "channel1", 8));
+  tg.run(Hello("push", "channel2", 10));
+  tg.run(Hello("push", "channel3", 5));
+
+  tg.run(Hello("push", "inexistentChannel1", 1));
+  tg.run(Hello("pop", "inexistentChannel2", 2));
 
 
   // We haven't called any pop(), so the default case will be triggered.


### PR DESCRIPTION
This PR is about details discussed in [this](https://github.com/marius92mc/csp-cpp/pull/10#issuecomment-361153340) comment, without the _parser_ part. That will be the subject of a different PR.  

> - Class / object for Select (initialize, trigger, etc)
> - Use channel objects with templates. Allow users to push/pop custom objects (use the
      implemented channels). Use references to channels instead of indices
> - Parser.
